### PR TITLE
Interface

### DIFF
--- a/bin/rspec-linter.rb
+++ b/bin/rspec-linter.rb
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+def test_file?(filename)
+  %w[_test.rb _spec.rb].any? { |suffix| filename.end_with? suffix }
+end

--- a/spec/rspec_linter_spec.rb
+++ b/spec/rspec_linter_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require_relative '../bin/rspec-linter'
+
+RSpec.describe 'rspec-linter' do
+  describe '#test_file' do
+    context 'when result is true' do
+      it 'filename ends with _test.rb' do
+        expect(test_file?('example_test.rb')).to be(true)
+      end
+
+      it 'filename ends with _spec.rb' do
+        expect(test_file?('example_spec.rb')).to be(true)
+      end
+    end
+
+    context 'when result is false' do
+      it 'file is not a test file' do
+        expect(test_file?('parser.rb')).to be(false)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,17 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+module FormatterOverrides
+  def dump_pending(_) end
+end
+
+RSpec::Core::Formatters::DocumentationFormatter.prepend FormatterOverrides


### PR DESCRIPTION
Pull request to add a command-line interface for the linter:
- The linter is to be called by running bin/rspec-linter.rb from the root directory of the folder.
- If one argument is given, the program will lint (stub logic) that file
- If no arguments are given, the program will lint (stub logic) all the files whose names end with '_lint.rb' or '_spec.rb' in the current directory, or in the spec subdirectory of the current one.
- The stub linting will just print back the filenames of the files to lint.